### PR TITLE
Bugfix: Equivalence issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
-# icd11
-ICD11 foundation ingest.
+# ICD11 Foundation Ingest
+
+## Pre-reqs
+- Docker
+- Docker images  
+  One or both of the following, depending on if you want to run the stable build `latest` or `dev`:
+  - a. `docker pull obolibrary/odkfull:latest`
+  - b. `docker pull obolibrary/odkfull:dev`
+
+## Running
+`sh run.sh make all`

--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := all
-.PHONY: all release
+.PHONY: all release clean
 TODAY ?=$(shell date +%Y-%m-%d)
 VERSION=v$(TODAY)
 SOURCE_URL=https://icd11files.blob.core.windows.net/tmp/whofic-2023-04-08.owl.gz
@@ -8,8 +8,14 @@ SOURCE_URL=https://icd11files.blob.core.windows.net/tmp/whofic-2023-04-08.owl.gz
 # MAIN COMMANDS / GOALS ------------------------------------------------------------------------------------------------
 all: tmp/output/release/icd11foundation.owl
 
+clean:
+	rm -rf tmp/
+
+tmp/output/release/icd11foundation.owl: tmp/output/intermediate1-unicode-cleaned.owl
+	robot remove --axioms equivalent -i $< -o $@
+
 # Cleans all unicode characters
-tmp/output/release/icd11foundation.owl: tmp/input/source.owl | tmp/output/release/
+tmp/output/intermediate1-unicode-cleaned.owl: tmp/input/source.owl | tmp/output/release/
 	tr -cd '\11\12\15\40-\176' < $< > $@
 
 tmp/output/release/:

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,107 @@
+#!/bin/sh
+# Wrapper script for docker.
+#
+# This is used primarily for wrapping the GNU Make workflow.
+# Instead of typing "make TARGET", type "./run.sh make TARGET".
+# This will run the make workflow within a docker container.
+#
+# The assumption is that you are working in the src/ontology folder;
+# we therefore map the whole repo (../..) to a docker volume.
+#
+# To use singularity instead of docker, please issue
+# export USE_SINGULARITY=<any-value>
+# before running this script.
+#
+# See README-editors.md for more details.
+
+set -e
+
+if [ -f run.sh.conf ]; then
+    . ./run.sh.conf
+fi
+
+# Look for a GitHub token
+if [ -n "$GH_TOKEN" ]; then
+    :
+elif [ -f ../../.github/token.txt ]; then
+    GH_TOKEN=$(cat ../../.github/token.txt)
+elif [ -f $XDG_CONFIG_HOME/ontology-development-kit/github/token ]; then
+    GH_TOKEN=$(cat $XDG_CONFIG_HOME/ontology-development-kit/github/token)
+elif [ -f "$HOME/Library/Application Support/ontology-development-kit/github/token" ]; then
+    GH_TOKEN=$(cat "$HOME/Library/Application Support/ontology-development-kit/github/token")
+fi
+
+# SSH agent socket
+# On macOS, we cannot use $SSH_AUTH_SOCK directly,
+# we need to use a "magic" socket instead.
+case "$(uname)" in
+Darwin)
+    ODK_SSH_AUTH_SOCKET=/run/host-services/ssh-auth.sock
+    ;;
+*)
+    ODK_SSH_AUTH_SOCKET=$SSH_AUTH_SOCK
+    ;;
+esac
+ODK_SSH_BIND=
+if [ -n "$ODK_SSH_AUTH_SOCKET" ]; then
+    ODK_SSH_BIND=",$ODK_SSH_AUTH_SOCKET:/run/host-services/ssh-auth.sock"
+fi
+
+ODK_IMAGE=${ODK_IMAGE:-odkfull}
+TAG_IN_IMAGE=$(echo $ODK_IMAGE | awk -F':' '{ print $2 }')
+if [ -n "$TAG_IN_IMAGE" ]; then
+  # Override ODK_TAG env var if IMAGE already includes a tag
+  ODK_TAG=$TAG_IN_IMAGE
+  ODK_IMAGE=$(echo $ODK_IMAGE | awk -F':' '{ print $1 }')
+fi
+ODK_TAG=${ODK_TAG:-latest}
+ODK_JAVA_OPTS=${ODK_JAVA_OPTS:--Xmx20G}
+ODK_DEBUG=${ODK_DEBUG:-no}
+
+ODK_USER_ID=${ODK_USER_ID:-$(id -u)}
+ODK_GROUP_ID=${ODK_GROUP_ID:-$(id -g)}
+
+# Convert OWLAPI_* environment variables to the OWLAPI as Java options
+# See http://owlcs.github.io/owlapi/apidocs_4/org/semanticweb/owlapi/model/parameters/ConfigurationOptions.html
+# for a list of allowed options
+OWLAPI_OPTIONS_NAMESPACE=org.semanticweb.owlapi.model.parameters.ConfigurationOptions
+for owlapi_var in $(env | sed -n s/^OWLAPI_//p) ; do
+    ODK_JAVA_OPTS="$ODK_JAVA_OPTS -D$OWLAPI_OPTIONS_NAMESPACE.${owlapi_var%=*}=${owlapi_var#*=}"
+done
+
+TIMECMD=
+if [ x$ODK_DEBUG = xyes ]; then
+    # If you wish to change the format string, take care of using
+    # non-breaking spaces (U+00A0) instead of normal spaces, to
+    # prevent the shell from tokenizing the format string.
+    echo "Running ${IMAGE} with ${ODK_JAVA_OPTS} of memory for ROBOT and Java-based pipeline steps."
+    TIMECMD="/usr/bin/time -f ### DEBUG STATS ###\nElapsed time: %E\nPeak memory: %M kb"
+fi
+rm -f tmp/debug.log
+
+VOLUME_BIND=$PWD/../../:/work$ODK_SSH_BIND
+WORK_DIR=/work/src/ontology
+
+if [ -n "$ODK_BINDS" ]; then
+    VOLUME_BIND="$VOLUME_BIND,$ODK_BINDS"
+fi
+
+if [ -n "$USE_SINGULARITY" ]; then
+    
+    singularity exec --cleanenv $ODK_SINGULARITY_OPTIONS \
+        --env "ROBOT_JAVA_ARGS=$ODK_JAVA_OPTS,JAVA_OPTS=$ODK_JAVA_OPTS,SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock,ODK_USER_ID=$ODK_USER_ID,ODK_GROUP_ID=$ODK_GROUP_ID,ODK_DEBUG=$ODK_DEBUG" \
+        --bind $VOLUME_BIND \
+        -W $WORK_DIR \
+        docker://obolibrary/$ODK_IMAGE:$ODK_TAG $TIMECMD "$@"
+else
+    BIND_OPTIONS="-v $(echo $VOLUME_BIND | sed 's/,/ -v /')"
+    docker run $ODK_DOCKER_OPTIONS $BIND_OPTIONS -w $WORK_DIR \
+        -e ROBOT_JAVA_ARGS="$ODK_JAVA_OPTS" -e JAVA_OPTS="$ODK_JAVA_OPTS" -e SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock -e ODK_USER_ID=$ODK_USER_ID -e ODK_GROUP_ID=$ODK_GROUP_ID -e ODK_DEBUG=$ODK_DEBUG \
+        --rm -ti obolibrary/$ODK_IMAGE:$ODK_TAG $TIMECMD "$@"
+fi
+
+case "$@" in
+*update_repo*|*release*)
+    echo "Please remember to update your ODK image from time to time: https://oboacademy.github.io/obook/howto/odk-update/."
+    ;;
+esac


### PR DESCRIPTION
Addresses:
- Equivalence problem mentioned here: https://github.com/monarch-initiative/mondo-ingest/pull/412#discussion_r1493469285

## Overview
This PR is a workaround for illogical class equivalence issues highlighted by the ontological reasoner. After applying this fix, it is expected that no such error will be thrown when running `build-mondo-ingest`.

## Pre-merge checklist
- [x] Docs
   - `docs/` have been added/updated **OR**
   - No updates to the docs necessary after careful consideration.
- [x] QC
   - `sh run.sh make build-mondo-ingest` has been run on this branch (after `docker pull obolibrary/odkfull:dev), and no errors occurred **OR**
   -  No functional (code-related) changes to the pipeline are suggested, so no re-run is necessary.
- [x] Account for any new packages
  - n/a
- [x] Reviewed
   - Has been sufficiently reviewed by at least one review from a different team member of the Mondo Technical team.

## Changes
Bugfix: Equivalence issues
Temporary fix for: `ERROR org.obolibrary.robot.ReasonOperation - Only equivalent classes that have been asserted are allowed. Inferred equivalencies are forbidden.`
- Update: makefile: Goal for removing equivalents axioms. See https://github.com/monarch-initiative/mondo-ingest/pull/412#discussion_r1494224976